### PR TITLE
Limit dependencies to `pip` declared one

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 84aa395a56f08f508a859ba65a963493891bfec4e0e9df59e4cdcced77a23076
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: '{{ PYTHON }} -m pip install . -vv '
 
@@ -26,7 +26,7 @@ requirements:
     - pandas >=0.23.4
     - patsy >=0.5.1
     - autograd >=1.2
-    - cvxpy >=1.0.24
+    - cvxpy-base >=1.0.24
     - Deprecated >=1.2.6
     - umap-learn >=0.4.3
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,19 +16,17 @@ build:
 
 requirements:
   host:
+    - python >=3.6
     - pip
-    - python >=3.5
   run:
-    - python >=3.5
-    - numpy >=1.16.0
-    - scipy >=1.2.0
-    - scikit-learn >=0.20.2
-    - pandas >=0.23.4
-    - patsy >=0.5.1
+    - python >=3.6
     - autograd >=1.2
-    - cvxpy-base >=1.0.24
-    - Deprecated >=1.2.6
-    - umap-learn >=0.4.3
+    - deprecated >=1.2.6
+    - pandas >=1.1.5
+    - patsy >=0.5.1
+    - python >=3.6
+    - scikit-learn >=0.24.1
+    - umap-learn >=0.4.6
 
 test:
   imports:


### PR DESCRIPTION
In conda-forge, we have a more minimal `cvxpy-base` package that provides only the core of `cvxpy` but doesn't install any of the solvers. Thus the user is free to chose which one they want to install and this can avoid installing GPL-licensed dependencies.